### PR TITLE
Fix for Issue #24

### DIFF
--- a/billiard/synchronize.py
+++ b/billiard/synchronize.py
@@ -104,6 +104,8 @@ class SemLock(object):
         sname = _semname(sl)
         if sname is not None:
             state += (sname, )
+        else:
+            state += ("", )
         return state
 
     def __setstate__(self, state):


### PR DESCRIPTION
Windows doesn't seem to have names for semaphores. The fix adds an empty string when the semaphore name is not available.
