### PR TITLE
Add check on variable check_timeouts

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -725,7 +725,8 @@ class ResultHandler(PoolThread):
 
         time_terminate = None
         while cache and self._state != TERMINATE:
-            check_timeouts()
+            if check_timeouts is not None:
+                check_timeouts()
             try:
                 ready, task = poll(1.0)
             except (IOError, EOFError), exc:


### PR DESCRIPTION
We are using celery with mongodb backend.In this case pool.py:Pool is initialized with threads=True and ResultHandler is initialized with check_timeouts=None.
