### PR TITLE
Update billiard/einfo.py

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -21,10 +21,13 @@ class _Frame(object):
             "__loader__": None,
         }
         self.f_locals = fl = {}
-        try:
-            fl["__traceback_hide__"] = frame.f_locals["__traceback_hide__"]
-        except KeyError:
-            pass
+        for k, v in frame.f_locals.items():
+            try:
+                pickle.loads(pickle.dumps(v))
+            except:
+                fl[k] = '<unknown>'
+            else:
+                fl[k] = v
         self.f_code = self.Code(frame.f_code)
         self.f_lineno = frame.f_lineno
 


### PR DESCRIPTION
This allows Sentry to show context locals while still keeping the traceback pickable (just removes unpickable local values)
