### PR TITLE
Fixed incorrect usage of `signal.signal` in `_trywaitkill`

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -515,7 +515,7 @@ class TimeoutHandler(PoolThread):
                 return
         debug('timeout: TERM timed-out, now sending KILL to %s', worker._name)
         try:
-            signal.signal(worker.pid, signal.SIGKILL)
+            _kill(worker.pid, signal.SIGKILL)
         except OSError:
             pass
 


### PR DESCRIPTION
Now uses `os.kill` instead.
