### PR TITLE
self._value is an ExceptionInfo, we can't raise it

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1383,7 +1383,7 @@ class ApplyResult(object):
         if self._success:
             return self._value
         else:
-            raise self._value
+            raise self._value.exception
 
     def _set(self, i, obj):
         with self._mutex:


### PR DESCRIPTION
Because billiard wraps exceptions in ExceptionInfo, we can't just raise the ._value that is returned from a worker.  We need to raise the ._value.exception.
