### PR TITLE
Fixing EX_RECYCLE exit code check and spelling mistake in pool.py

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -942,10 +942,10 @@ class Pool(object):
                 # worker exited
                 debug('Supervisor: cleaning up worker %d', i)
                 worker.join()
-                debug('Supervisor: worked %d joined', i)
+                debug('Supervisor: worker %d joined', i)
                 cleaned[worker.pid] = worker
                 exitcodes[worker.pid] = worker.exitcode
-                if -worker.exitcode not in (EX_OK, EX_RECYCLE):
+                if worker.exitcode not in (EX_OK, EX_RECYCLE):
                     error('Process %r pid:%r exited with exitcode %r' % (
                         worker.name, worker.pid, -worker.exitcode))
                 del self._pool[i]


### PR DESCRIPTION
The check for exist statuses was throwing an ERROR condition when it shouldn't have because of the minus sign in the if clause. Removing it seems to have resolved the issue on my test machine with Celery 3.0.15.
