### PR TITLE
Update setup.py to handle no compiler being found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,8 @@ def run_setup(with_extensions=True):
 
 try:
     run_setup(not (is_jython or is_pypy or is_py3k))
-except (Exception):
+except (Exception, SystemExit): 
+    # run_setup() throws SystemExit if no compiler is found. Don't ask me why.
     import traceback
     sys.stderr.write(BUILD_WARNING % '\n'.join(traceback.format_stack(), ))
     run_setup(False)


### PR DESCRIPTION
run_setup() throws SystemExit when no compiler is found. No idea why, but this is a fix for it.
