### PR TITLE
Fix invalid argument bug when running in Python3.3

### DIFF
--- a/billiard/common.py
+++ b/billiard/common.py
@@ -15,7 +15,8 @@ def _shutdown_cleanup(signum, frame):
 def reset_signals(handler=_shutdown_cleanup):
     for i in range(signal.NSIG):
         try:
-            if signal.getsignal(i) != signal.SIG_IGN:
+            if signal.getsignal(i) != signal.SIG_IGN and \
+                    signal.getsignal(i) is not None:
                 signal.signal(i, handler)
         except (ValueError, RuntimeError):
             pass


### PR DESCRIPTION
reset_signals() will cause OSError: [Errno 22] Invalid argument when running celery in Python 3.3 on OS X 10.8.3.

It's because signal.getsignal(signal.SIGKILL) and signal.getsignal(signal.SIGSTOP) will return None value.

I've tested the change on my machine, and it fixes the bug.
