### PR TITLE
Fix billiard.pool import for Python 3.2

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -60,7 +60,7 @@ except AttributeError:  # pragma: no cover
     TIMEOUT_MAX = 1e10  # noqa
 
 
-if PY3:
+if sys.version_info[:2] >= (3, 3):
     _Semaphore = threading.Semaphore
 else:
     _Semaphore = threading._Semaphore  # noqa


### PR DESCRIPTION
``` python
Python 3.2.3 (default, Apr 28 2013, 16:18:44) 
[GCC 4.8.0 20130411 (prerelease)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import billiard.pool
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "billiard/pool.py", line 122, in <module>
    class LaxBoundedSemaphore(_Semaphore):
TypeError: function() argument 1 must be code, not str
```

`threading.Semaphore` is a function in Python<=3.2 and a class in Python 3.3.

Billiard considered it to be a class in Python>=3.0.
