### PR TITLE
Not proper handling of 'HAVE_SEM_OPEN' config var causes a build error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ elif sys.platform in ('freebsd4', 'freebsd5', 'freebsd6'):
     libraries = []
 elif sys.platform in ('freebsd7', 'freebsd8', 'freebsd9', 'freebsd10'):
     macros = dict(                  # FreeBSD 7+
-            HAVE_SEM_OPEN=int(sysconfig.get_config_var('HAVE_SEM_OPEN') and not bool(sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED'))),
+            HAVE_SEM_OPEN=bool(sysconfig.get_config_var('HAVE_SEM_OPEN') and not bool(sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED'))),
             HAVE_SEM_TIMEDWAIT=1,
             HAVE_FD_TRANSFER=1,
         )


### PR DESCRIPTION
During installation of billiard on a machine running `FreeBSD web 7.1-RELEASE-p13` I have encountered a problem that aborted the build process.

```
Downloading/unpacking billiard>=2.7.3.28,<3.0 (from celery>=3.0.15,<3.1.0->sentry==dev)
  Downloading billiard-2.7.3.28.tar.gz (132Kb): 132Kb downloaded
  Running setup.py egg_info for package billiard
    Traceback (most recent call last):
      File "<string>", line 14, in <module>
      File "/root/build/billiard/setup.py", line 123, in <module>
        HAVE_SEM_OPEN=int(sysconfig.get_config_var('HAVE_SEM_OPEN') and not bool(sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED'))),
    TypeError: int() argument must be a string or a number, not 'NoneType'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 14, in <module>

  File "/root/build/billiard/setup.py", line 123, in <module>

    HAVE_SEM_OPEN=int(sysconfig.get_config_var('HAVE_SEM_OPEN') and not bool(sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED'))),

TypeError: int() argument must be a string or a number, not 'NoneType'
```

The posix semaphores are not present on my system and for this reason HAVE_SEM_OPEN and POSIX_SEMAPHORES_NOT_ENABLED both return None.

```
Python 2.6.5 (r265:79063, Aug  4 2010, 19:10:39)
[GCC 4.2.1 20070719  [FreeBSD]] on freebsd7
Type "help", "copyright", "credits" or "license" for more information.
>>> from distutils import sysconfig
>>> sysconfig.get_config_var('HAVE_SEM_OPEN')
>>> sysconfig.get_config_var('POSIX_SEMAPHORES_NOT_ENABLED')
>>> sysconfig.get_config_var('LIBPL')
'/usr/local/lib/python2.6/config'
```

The patch I submit resolves the issue, by using the bool function instead of int.
