### PR TITLE
Tiny Python 3k fix

### DIFF
--- a/billiard/process.py
+++ b/billiard/process.py
@@ -253,7 +253,7 @@ class Process(object):
             # Workaround for http://bugs.python.org/issue6721/#msg140215
             # Python logging module uses RLock() objects which are broken
             # after fork. This can result in a deadlock (Celery Issue #496).
-            logger_names = logging.Logger.manager.loggerDict.keys()
+            logger_names = list(logging.Logger.manager.loggerDict.keys())
             logger_names.append(None)  # for root logger
             for name in logger_names:
                 for handler in logging.getLogger(name).handlers:


### PR DESCRIPTION
[2013-07-09 13:42:12,034: ERROR/MainProcess] Process Worker-3
Traceback (most recent call last):
  File "python3.2/site-packages/billiard-3.3.0.0rc1-py3.2.egg/billiard/process.py", line 257, in _bootstrap
    logger_names.append(None)  # for root logger
AttributeError: 'dict_keys' object has no attribute 'append'

The return value of dict_keys() needs to be converted to a list explicitly.
