### PR TITLE
Small fix in PyPy check - getattr raises exceptions on missing

### DIFF
--- a/billiard/_reduction.py
+++ b/billiard/_reduction.py
@@ -24,7 +24,7 @@ from ._ext import _billiard, win32
 from .util import register_after_fork, debug, sub_debug
 
 is_win32 = sys.platform == 'win32'
-is_pypy = getattr(sys, 'pypy_version_info')
+is_pypy = hasattr(sys, 'pypy_version_info')
 is_py3k = sys.version_info[0] == 3
 
 if not(is_win32 or is_pypy or is_py3k or hasattr(_billiard, 'recvfd')):


### PR DESCRIPTION
attributes.

This was causing unit tests on Celery develop to error our in a major way.
