### PR TITLE
Windows/Python 3.3: Missing import and invalid handles in forked processes

### DIFF
--- a/billiard/_connection3.py
+++ b/billiard/_connection3.py
@@ -30,10 +30,14 @@ try:
     import _winapi
     from _winapi import (
         WAIT_OBJECT_0,
-        WAIT_ABANDONED_0,
         WAIT_TIMEOUT,
         INFINITE,
     )
+    # if we got here, we seem to be running on Windows. Handle probably missing WAIT_ABANDONED_0 constant:
+    try:
+        from _winapi import WAIT_ABANDONED_0
+    except ImportError:
+         WAIT_ABANDONED_0 = 128 # _winapi seems to be not exporting this constant, fallback solution until exported in _winapi
 except ImportError:
     if sys.platform == 'win32':
         raise
@@ -540,6 +544,7 @@ if sys.platform != 'win32':
         return c1, c2
 
 else:
+    from billiard.forking import duplicate
 
     def Pipe(duplex=True, rnonblock=False, wnonblock=False):  # noqa
         '''
@@ -574,9 +579,10 @@ else:
         _, err = overlapped.GetOverlappedResult(True)
         assert err == 0
 
-        c1 = PipeConnection(h1, writable=duplex)
-        c2 = PipeConnection(h2, readable=duplex)
-
+        c1 = PipeConnection(duplicate(h1, inheritable=True), writable=duplex)
+        c2 = PipeConnection(duplicate(h2, inheritable=True), readable=duplex)
+        _winapi.CloseHandle(h1)
+        _winapi.CloseHandle(h2)
         return c1, c2
 
 #


### PR DESCRIPTION
Fallback for missing _winapi.WAIT_ABANDONED_0. PipeConnection handles can now be inherited by forked processes (the forked process tried to use them but failed, as they've been created without SECURITY_ATTRIBUTES -> CreateNamedPipe defaults to not inheritable).
