### PR TITLE
Run os._exit even if outq.put fails.

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -298,8 +298,8 @@ class Worker(Process):
             self.on_exit(pid, exitcode)
 
         if sys.platform != 'win32':
-            self.outq.put((DEATH, (pid, exitcode)))
             try:
+                self.outq.put((DEATH, (pid, exitcode)))
                 time.sleep(1)
             finally:
                 os._exit(exitcode)


### PR DESCRIPTION
I was getting spurious errors like this:

```
[pid=4743 processName=Worker-6 - 2013-12-04 18:23:50,310]: multiprocessing - ERROR - Process Worker-6
Traceback (most recent call last):
  File "/home/ionel/projects/core/.ve/local/lib/python2.7/site-packages/billiard/process.py", line 292, in _bootstrap
    self.run()
  File "/home/ionel/projects/core/.ve/local/lib/python2.7/site-packages/billiard/pool.py", line 291, in run
    self._do_exit(pid, _exitcode[0], None)
  File "/home/ionel/projects/core/.ve/local/lib/python2.7/site-packages/billiard/pool.py", line 301, in _do_exit
    self.outq.put((DEATH, (pid, exitcode)))
OSError: [Errno 32] Broken pipe
```
