### PR TITLE
Fixed bug while installing on py3k

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,8 @@ Changes
 
 """
 long_description += open(os.path.join(HERE, 'CHANGES.txt')).read()
-long_description = long_description.encode('ascii', 'replace')
+if not is_py3k:
+    long_description = long_description.encode('ascii', 'replace')
 
 # -*- Installation Requires -*-
 


### PR DESCRIPTION
"long_description" must be a 'str' object.  This was breaking the installation process.
