### PR TITLE
do not catch SIGBUS either as per SIG35-C

### DIFF
--- a/billiard/common.py
+++ b/billiard/common.py
@@ -45,7 +45,6 @@ TERMSIGS = (
     'SIGTRAP',
     'SIGABRT',
     'SIGEMT',
-    'SIGBUS',
     'SIGSYS',
     'SIGPIPE',
     'SIGALRM',


### PR DESCRIPTION
This related to commit: 2bef62a7561ccca8509a4ceaaf471967c5737fb6
SIGBUS is also in the list of Signals that should not be caught. see:
https://www.securecoding.cert.org/confluence/display/seccode/SIG35-C.+Do+not+return+from+a+computational+exception+signal+handler
