### PR TITLE
Use dill to pickle whenever available

### DIFF
--- a/Modules/_billiard/multiprocessing.h
+++ b/Modules/_billiard/multiprocessing.h
@@ -144,12 +144,12 @@ extern HANDLE sigint_event;
  */
 
 #if PY_VERSION_HEX >= 0x03000000
-#  define PICKLE_MODULE "pickle"
+#  define PICKLE_MODULE "dill"
 #  define FROM_FORMAT PyUnicode_FromFormat
 #  define PyInt_FromLong PyLong_FromLong
 #  define PyInt_FromSsize_t PyLong_FromSsize_t
 #else
-#  define PICKLE_MODULE "cPickle"
+#  define PICKLE_MODULE "dill"
 #  define FROM_FORMAT PyString_FromFormat
 #endif
 

--- a/billiard/common.py
+++ b/billiard/common.py
@@ -9,6 +9,12 @@ import signal
 import sys
 
 import pickle as pypickle
+
+try:
+    import dill
+except ImportError:
+    dill = None
+
 try:
     import cPickle as cpickle
 except ImportError:  # pragma: no cover
@@ -17,13 +23,13 @@ except ImportError:  # pragma: no cover
 from .exceptions import RestartFreqExceeded
 from .five import monotonic
 
-if sys.version_info < (2, 6):  # pragma: no cover
+if sys.version_info < (2, 6) and not dill:  # pragma: no cover
     # cPickle does not use absolute_imports
     pickle = pypickle
     pickle_load = pypickle.load
     pickle_loads = pypickle.loads
 else:
-    pickle = cpickle or pypickle
+    pickle = dill or cpickle or pypickle
     pickle_load = pickle.load
     pickle_loads = pickle.loads
 

--- a/billiard/common.py
+++ b/billiard/common.py
@@ -8,30 +8,14 @@ import os
 import signal
 import sys
 
-import pickle as pypickle
-
-try:
-    import dill
-except ImportError:
-    dill = None
-
-try:
-    import cPickle as cpickle
-except ImportError:  # pragma: no cover
-    cpickle = None   # noqa
+import dill
 
 from .exceptions import RestartFreqExceeded
 from .five import monotonic
 
-if sys.version_info < (2, 6) and not dill:  # pragma: no cover
-    # cPickle does not use absolute_imports
-    pickle = pypickle
-    pickle_load = pypickle.load
-    pickle_loads = pypickle.loads
-else:
-    pickle = dill or cpickle or pypickle
-    pickle_load = pickle.load
-    pickle_loads = pickle.loads
+pickle = dill
+pickle_load = pickle.load
+pickle_loads = pickle.loads
 
 # cPickle.loads does not support buffer() objects,
 # but we can just create a StringIO and use load.

--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,7 @@ def run_setup(with_extensions=True):
         zip_safe=False,
         license='BSD',
         tests_require=tests_require,
-        extra_requires={'dill': ['dill']},
+        install_requires=['dill'],
         test_suite='nose.collector',
         classifiers=[
             'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -231,6 +231,7 @@ def run_setup(with_extensions=True):
         zip_safe=False,
         license='BSD',
         tests_require=tests_require,
+        extra_requires={'dill': ['dill']},
         test_suite='nose.collector',
         classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
[dill](https://github.com/uqfoundation/dill) can pickle almost anything. As a result it will allow us to avoid errors like this: http://stackoverflow.com/questions/17960296/trouble-using-a-lock-with-multiprocessing-pool-pickling-error

To reproduce:

``` python
import billiard as mp
import Queue

def foo(queue):
    pass

pool=mp.Pool()
q=Queue.Queue()

pool.map(foo,(q,))
```

Now install billiard and dill with this branch and it should work.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/celery/billiard/131)

<!-- Reviewable:end -->
