### PR TITLE
This adds a utf-8 encoding line to connection.py

### DIFF
--- a/billiard/connection.py
+++ b/billiard/connection.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # A higher level module for using sockets (or Windows named pipes)
 #


### PR DESCRIPTION
Before this I was getting the error:

```
Traceback (most recent call last):
  File "/home/sontek/venvs/celery/local/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/home/sontek/venvs/celery/local/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/home/sontek/venvs/celery/local/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/home/sontek/venvs/celery/local/lib/python2.7/site-packages/nose/util.py", line 470, in try_run
    return func()
  File "/home/sontek/venvs/celery/src/celery/celery/tests/__init__.py", line 33, in setup
    import_all_modules()
  File "/home/sontek/venvs/celery/src/celery/celery/tests/__init__.py", line 90, in import_all_modules
    import_module(module)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/sontek/venvs/celery/src/celery/celery/tests/concurrency/test_prefork.py", line 14, in <module>
    from celery.concurrency import prefork as mp
  File "/home/sontek/venvs/celery/src/celery/celery/concurrency/prefork.py", line 14, in <module>
    from billiard.pool import RUN, CLOSE, Pool as BlockingPool
  File "/home/sontek/venvs/celery/src/billiard/billiard/pool.py", line 34, in <module>
    from .dummy import DummyProcess
  File "/home/sontek/venvs/celery/src/billiard/billiard/dummy/__init__.py", line 56, in <module>
    from billiard.connection import Pipe
  File "/home/sontek/venvs/celery/src/billiard/billiard/connection.py", line 433
SyntaxError: Non-ASCII character '\xe2' in file /home/sontek/venvs/celery/src/billiard/billiard/connection.py on line 433, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

```