### PR TITLE
Use `io.open` when opening the file descriptor.

### DIFF
--- a/billiard/popen_spawn_posix.py
+++ b/billiard/popen_spawn_posix.py
@@ -67,7 +67,7 @@ class Popen(popen_fork.Popen):
                 spawn.get_executable(), cmd, self._fds,
             )
             self.sentinel = parent_r
-            with open(parent_w, 'wb', closefd=False) as f:
+            with io.open(parent_w, 'wb', closefd=False) as f:
                 f.write(fp.getbuffer())
         finally:
             if parent_r is not None:


### PR DESCRIPTION
Fixes #149