### PR TITLE
Use `getvalue` with `io.BytesIO` instance.

### DIFF
--- a/billiard/popen_spawn_posix.py
+++ b/billiard/popen_spawn_posix.py
@@ -67,7 +67,7 @@ class Popen(popen_fork.Popen):
                 spawn.get_executable(), cmd, self._fds,
             )
             self.sentinel = parent_r
-            with open(parent_w, 'wb', closefd=False) as f:
+            with io.open(parent_w, 'wb', closefd=False) as f:
                 f.write(fp.getbuffer())
         finally:
             if parent_r is not None:

--- a/billiard/popen_spawn_posix.py
+++ b/billiard/popen_spawn_posix.py
@@ -68,7 +68,7 @@ class Popen(popen_fork.Popen):
             )
             self.sentinel = parent_r
             with io.open(parent_w, 'wb', closefd=False) as f:
-                f.write(fp.getbuffer())
+                f.write(fp.getvalue())
         finally:
             if parent_r is not None:
                 util.Finalize(self, os.close, (parent_r,))


### PR DESCRIPTION
Fixes #151. Contains solution from #150, which should be merged first.