### PR TITLE
.gitignore: Ignore PyCharm project directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 *.sqlite
 *.sqlite-journal
+.idea/
 settings_local.py
 local_settings.py
 .*.sw[po]


### PR DESCRIPTION
Just tells git to ignore the PyCharm project directory, as stated.