### PR TITLE
Fix grammatical error in readme: it's -> its

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ About
 package. The multiprocessing package itself is a renamed and updated version of
 R Oudkerk's `pyprocessing <http://pypi.python.org/pypi/processing/>`_ package.
 This standalone variant is intended to be compatible with Python 2.4 and 2.5,
-and will draw it's fixes/improvements from python-trunk.
+and will draw its fixes/improvements from python-trunk.
 
 - This package would not be possible if not for the contributions of not only
   the current maintainers but all of the contributors to the original pyprocessing


### PR DESCRIPTION
"its" shouldn't have an apostrophe when using it in possessive form