### PR TITLE
Don't attempt to send SIGKILL on win32

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -664,11 +664,15 @@ class TimeoutHandler(PoolThread):
         else:
             if worker._popen.wait(timeout=0.1):
                 return
-        debug('timeout: TERM timed-out, now sending KILL to %s', worker._name)
-        try:
-            _kill(worker.pid, SIGKILL)
-        except OSError:
-            pass
+
+        debug('timeout: TERM timed-out on %s', worker._name)
+
+        if sys.platform != 'win32':
+            debug('timeout: now sending KILL to %s', worker._name)
+            try:
+                _kill(worker.pid, SIGKILL)
+            except OSError:
+                pass
 
     def handle_timeouts(self):
         cache = self.cache


### PR DESCRIPTION
This might be a long shot, but on Windows hard task time limits work properly as long as they get killed during the SIGTERM and never reach the SIGKILL logic. Sometimes under load processes will take longer than 0.1 seconds to terminate and then the celery "master" process will crash when attempting to SIGKILL because the signal module doesn't have that attribute on Windows.

This is a quick but really important stability fix for us that I think others would benefit from... even if this isn't technically a supported feature (soft/hard task timeouts) on Windows.