### PR TITLE
Ensure that the LICENSE file is included in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,7 @@ ignore = N806, N802, N801, N803
 [pep257]
 ignore = D102,D104,D203,D105
 
+[metadata]
+license_file = LICENSE.txt
+
 


### PR DESCRIPTION
Without this setting the license file is not included in
the built wheels