### PR TITLE
Extend 'Process' to be compatible with < Py3.5

### DIFF
--- a/billiard/process.py
+++ b/billiard/process.py
@@ -243,6 +243,16 @@ class BaseProcess(object):
         # compat for 2.7
         return self.authkey
 
+    @property
+    def _daemonic(self):
+        # compat for 2.7
+        return self.daemon
+
+    @property
+    def _tempdir(self):
+        # compat for 2.7
+        return self._config.get('tempdir')
+
     def __repr__(self):
         if self is _current_process:
             status = 'started'


### PR DESCRIPTION
In order to be compatible with Python versions below < 3.5, we need to
define the following properties on Process instance:

  * _authkey
  * _daemonic
  * _tempdir

It's very essential to have them defined since otherwise any attempt to
start 'multiprocessing.Process' from within 'billiard.Process' fails
trying to inherit those values from '_current_process'.

That basically means it's impossible to start 'multiprocessing.Process'
in Celery task and therefore it limits Celery usage. For instance,
Ansible uses 'multiprocessing.Process' under the hood and inability to
run it from Celery task is incredibly inconvenient.