### PR TITLE
Remove superfluous else clause from max_memory_per_child_check

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -380,8 +380,6 @@ class Worker(object):
                         error(MAXMEM_USED_FMT.format(
                             used_kb, max_memory_per_child))
                         return EX_RECYCLE
-                    else:
-                        error('worker unable to determine worker memory usage')
 
         debug('worker exiting after %d tasks', completed)
         if maxtasks:


### PR DESCRIPTION
This fixes issue https://github.com/celery/billiard/issues/205 where the worker will output "worker unable to determine worker memory usage" in the the "happy" case where the worker is below the memory usage limit. The error case (when it's unable to determine memory usage) is already handled above by checking for user_kb <= 0. Removing the else clause will allow the code to drop into the next check (for maxtasks) before returning EX_OK.