### PR TITLE
Problem: 'Process' object has no attribute 'daemonic'

### DIFF
--- a/billiard/process.py
+++ b/billiard/process.py
@@ -239,6 +239,11 @@ class BaseProcess(object):
         return _children
 
     @property
+    def _daemonic(self):
+        # compat for 2.7
+        return self.daemon
+
+    @property
     def _authkey(self):
         # compat for 2.7
         return self.authkey

--- a/billiard/process.py
+++ b/billiard/process.py
@@ -239,6 +239,11 @@ class BaseProcess(object):
         return _children
 
     @property
+    def _tempdir(self):
+        # compat for 2.7
+        return None
+
+    @property
     def _daemonic(self):
         # compat for 2.7
         return self.daemon


### PR DESCRIPTION
**Solution:** add `_daemonic` and `_tempdir` to billiard's Process, to avoid falling back into Python 2.7's multiprocessing.Process

**Background:**

Celery tasks that execute ansible were failing with:
  https://github.com/celery/celery/issues/3634

after testing the latest revision of billiard,
the next failure that showed up in python 2.7 was:
```
  File "/usr/lib/python2.7/multiprocessing/process.py", line 99, in__init__
      self._daemonic = _current_process._daemonic
  AttributeError: 'Process' object has no attribute '_daemonic'
```
After including this commit, I was able to run Ansible + prefork
using celery==4.0.2, ansible==2.1.0.0 (Possible solution to
https://github.com/celery/billiard/issues/203 ?)