### PR TITLE
Fix indentation error

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -672,8 +672,8 @@ class TimeoutHandler(PoolThread):
 
     def _trywaitkill(self, worker):
         debug('timeout: sending TERM to %s', worker._name)
-        try:            
-	    if os.getpgid(worker.pid) == worker.pid:
+        try:
+            if os.getpgid(worker.pid) == worker.pid:
                 debug("worker %s is a group leader. It is safe to kill (SIGTERM) the whole group", worker.pid)
                 os.killpg(os.getpgid(worker.pid), signal.SIGTERM)
             else:


### PR DESCRIPTION
This addresses an indentation error that cause a python interpreter error introduced in https://github.com/celery/billiard/commit/a0bdb57b9b5d78411bdb0a18486f5e8d2fa33a33