### PR TITLE
Fix for crash on windows

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -997,13 +997,7 @@ class Pool(object):
         if on_process_exit is not None and not callable(on_process_exit):
             raise TypeError('on_process_exit must be callable')
 
-        class Process(self._ctx.Process):
-            _controlled_termination = False
-
-            def terminate_controlled(self):
-                self._controlled_termination = True
-                self.terminate()
-        self._Process = Process
+        self._Process = self._ctx.Process
 
         self._pool = []
         self._poolctrl = {}

--- a/billiard/process.py
+++ b/billiard/process.py
@@ -103,6 +103,8 @@ class BaseProcess(object):
             self.daemon = daemon
         if _dangling is not None:
             _dangling.add(self)
+        
+        self._controlled_termination = False
 
     def run(self):
         '''
@@ -132,6 +134,10 @@ class BaseProcess(object):
         Terminate process; sends SIGTERM signal or uses TerminateProcess()
         '''
         self._popen.terminate()
+        
+    def terminate_controlled(self):
+        self._controlled_termination = True
+        self.terminate()
 
     def join(self, timeout=None):
         '''

--- a/t/unit/test_pool.py
+++ b/t/unit/test_pool.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+import billiard.pool
+
+class test_pool:
+    def test_raises(self):
+        pool = billiard.pool.Pool()
+        assert pool.did_start_ok() is True
+        pool.close()
+        pool.terminate()


### PR DESCRIPTION
As there is no fork support on windows pickle is used to transfer the process state. Unfortunately pickle can't handle nested classes causing a crash. FIX: Moved one boolean variable to process instance variable and removed nested class from pool