### PR TITLE
Fix rebuild_ctype losing BufferedWrapper reference on Python 3

### DIFF
--- a/billiard/heap.py
+++ b/billiard/heap.py
@@ -73,11 +73,12 @@ else:
             self.size = size
             self.fd = fd
             if fd == -1:
-                self.fd, name = tempfile.mkstemp(
-                    prefix='pym-%d-' % (os.getpid(), ),
-                    dir=util.get_temp_dir(),
-                )
                 if PY3:
+                    self.fd, name = tempfile.mkstemp(
+                        prefix='pym-%d-' % (os.getpid(),),
+                        dir=util.get_temp_dir(),
+                    )
+
                     os.unlink(name)
                     util.Finalize(self, os.close, (self.fd,))
                     with io.open(self.fd, 'wb', closefd=False) as f:
@@ -90,6 +91,10 @@ else:
                         f.write(b'\0' * (size % bs))
                         assert f.tell() == size
                 else:
+                    name = tempfile.mktemp(
+                        prefix='pym-%d-' % (os.getpid(),),
+                        dir=util.get_temp_dir(),
+                    )
                     self.fd = os.open(
                         name, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600,
                     )

--- a/billiard/sharedctypes.py
+++ b/billiard/sharedctypes.py
@@ -155,7 +155,7 @@ def rebuild_ctype(type_, wrapper, length):
         obj = type_.from_buffer(buf)
     else:
         obj = type_.from_address(wrapper.get_address())
-        obj._wrapper = wrapper
+    obj._wrapper = wrapper
     return obj
 
 #

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -14,6 +14,7 @@ from billiard.common import (
     reset_signals,
     restart_state,
 )
+from billiard import Value
 
 
 def signo(name):
@@ -97,3 +98,17 @@ class test_restart_state:
         s.R, s.T = 100, time()
         s.step(time() + 20)
         assert s.R == 1
+
+
+class test_values:
+
+    def test_issue_229(self):
+        """Test fix for issue #229"""
+
+        a = Value('i', 0)
+        b = Value('i', 0)
+
+        a.value = 5
+        assert a.value == 5
+        assert b.value == 0
+

--- a/t/unit/test_common.py
+++ b/t/unit/test_common.py
@@ -14,7 +14,6 @@ from billiard.common import (
     reset_signals,
     restart_state,
 )
-from billiard import Value
 
 
 def signo(name):
@@ -98,17 +97,3 @@ class test_restart_state:
         s.R, s.T = 100, time()
         s.step(time() + 20)
         assert s.R == 1
-
-
-class test_values:
-
-    def test_issue_229(self):
-        """Test fix for issue #229"""
-
-        a = Value('i', 0)
-        b = Value('i', 0)
-
-        a.value = 5
-        assert a.value == 5
-        assert b.value == 0
-

--- a/t/unit/test_values.py
+++ b/t/unit/test_values.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import
+import pytest
+
+from billiard import Value, RawValue, Lock, Process
+
+
+class test_values:
+
+    codes_values = [
+        ('i', 4343, 24234),
+        ('d', 3.625, -4.25),
+        ('h', -232, 234),
+        ('c', 'x'.encode('latin'), 'y'.encode('latin'))
+        ]
+
+    def test_issue_229(self):
+        """Test fix for issue #229"""
+
+        a = Value('i', 0)
+        b = Value('i', 0)
+
+        a.value = 5
+        assert a.value == 5
+        assert b.value == 0
+
+    @classmethod
+    def _test(cls, values):
+        for sv, cv in zip(values, cls.codes_values):
+            sv.value = cv[2]
+
+    def test_value(self, raw=False):
+        if raw:
+            values = [RawValue(code, value)
+                      for code, value, _ in self.codes_values]
+        else:
+            values = [Value(code, value)
+                      for code, value, _ in self.codes_values]
+
+        for sv, cv in zip(values, self.codes_values):
+            assert sv.value == cv[1]
+
+        proc = Process(target=self._test, args=(values,))
+        proc.daemon = True
+        proc.start()
+        proc.join()
+
+        for sv, cv in zip(values, self.codes_values):
+            assert sv.value == cv[2]
+
+    def test_rawvalue(self):
+        self.test_value(raw=True)
+
+    def test_getobj_getlock(self):
+        val1 = Value('i', 5)
+        lock1 = val1.get_lock()
+        obj1 = val1.get_obj()
+
+        val2 = Value('i', 5, lock=None)
+        lock2 = val2.get_lock()
+        obj2 = val2.get_obj()
+
+        lock = Lock()
+        val3 = Value('i', 5, lock=lock)
+        lock3 = val3.get_lock()
+        obj3 = val3.get_obj()
+        assert lock == lock3
+
+        arr4 = Value('i', 5, lock=False)
+        assert not hasattr(arr4, 'get_lock')
+        assert not hasattr(arr4, 'get_obj')
+
+        with pytest.raises(AttributeError):
+            Value('i', 5, lock='navalue')
+
+        arr5 = RawValue('i', 5)
+        assert not hasattr(arr5, 'get_lock')
+        assert not hasattr(arr5, 'get_obj')


### PR DESCRIPTION
Fixes #229 

This is most likely a regression introduced when porting billiard to Python 3 which was for some reason uncovered.