### PR TITLE
fix(): issue with dummy in multiprocessing http://bit.ly/2wpiRtV

### DIFF
--- a/billiard/dummy/__init__.py
+++ b/billiard/dummy/__init__.py
@@ -68,7 +68,8 @@ class DummyProcess(threading.Thread):
     def start(self):
         assert self._parent is current_process()
         self._start_called = True
-        self._parent._children[self] = None
+        if hasattr(self._parent, '_children'):
+            self._parent._children[self] = None
         threading.Thread.start(self)
 
     @property


### PR DESCRIPTION
Hey guys,

is it possible to quickly fix this in 3.3?
I'm wary of moving to celery 4 for now due to issues reported with kombu and SQS but I'm hitting the known multiprocessing.dummy bug