### PR TITLE
Pass max_memory_per_child to child worker process

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -268,7 +268,7 @@ class Worker(object):
         return self.__class__, (
             self.inq, self.outq, self.synq, self.initializer,
             self.initargs, self.maxtasks, self._shutdown, self.on_exit,
-            self.sigprotection, self.wrap_exception,
+            self.sigprotection, self.wrap_exception, self.max_memory_per_child,
         )
 
     def __call__(self):


### PR DESCRIPTION
This fixes issue on Windows, where forking is made via multi-processing. The configuration parameter "max_memory_per_child" was not passed to the child process. So, an automatic restart of a worker after reaching a memory limit didn't work.