### PR TITLE
billiard.einfo.Frame: add `f_back` attribute

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -41,6 +41,7 @@ class _Frame(object):
             fl["__traceback_hide__"] = frame.f_locals["__traceback_hide__"]
         except KeyError:
             pass
+        self.f_back = None
         self.f_trace = None
         self.f_exc_traceback = None
         self.f_exc_type = None


### PR DESCRIPTION
Standard Python frame objects have a `f_back` attribute, which is used
in places such as the Django AdminEmailHandler. The lack of this
attribute in the billiard Frame causes a crash when celery is used in
Django apps, configured to use Django logging, and AdminEmailHandler is
in use. See for example Django bug #27543:

https://code.djangoproject.com/ticket/27543

In general, this also makes the billiard Frame object more compatible
with any code that handles frames, and could be using `f_back`.