### PR TITLE
Add support of sending parent process death signal

### DIFF
--- a/billiard/util.py
+++ b/billiard/util.py
@@ -170,6 +170,9 @@ def get_pdeathsig():
     """
     Return the current value of the parent process death signal
     """
+    if not sys.platform.startswith('linux'):
+        # currently we support only linux platform.
+        raise OSError()
     try:
         if 'cffi' in sys.modules:
             ffi = cffi.FFI()
@@ -195,6 +198,9 @@ def set_pdeathsig(sig):
     This value is cleared for the child of a fork(2) and
     (since Linux 2.4.36 / 2.6.23) when executing a set-user-ID or set-group-ID binary.
     """
+    if not sys.platform.startswith('linux'):
+        # currently we support only linux platform.
+        raise OSError()
     try:
         if 'cffi' in sys.modules:
             ffi = cffi.FFI()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 case>=1.3.1
 pytest>=3.0
+psutil

--- a/t/unit/test_spawn.py
+++ b/t/unit/test_spawn.py
@@ -28,6 +28,8 @@ class test_spawn:
         with pytest.raises(psutil.NoSuchProcess):
             proc = psutil.Process(return_pid.value)
 
+    @pytest.mark.skipif(not sys.platform.startswith('linux'),
+                        reason='get_pdeathsig() is supported only in Linux')
     def test_set_get_pdeathsig(self):
         sig = get_pdeathsig()
         assert sig == 0

--- a/t/unit/test_spawn.py
+++ b/t/unit/test_spawn.py
@@ -24,7 +24,7 @@ class test_spawn:
         p = Process(target=parent_task, args=(return_pid,))
         p.start()
         p.join()
-        sleep(1)    # We need to wait to have child process killed.
+        sleep(5)    # We need to wait to have child process killed.
         with pytest.raises(psutil.NoSuchProcess):
             proc = psutil.Process(return_pid.value)
 
@@ -37,17 +37,15 @@ class test_spawn:
         sig = get_pdeathsig()
         assert sig == signal.SIGTERM
 
-def child_process(child_started):
+def child_process():
     set_pdeathsig(signal.SIGTERM)
-    child_started.set()
     while True:
         sleep(1)
 
 def parent_task(return_pid):
-    child_started = Event()
-    p = Process(target=child_process, args=(child_started,))
+    p = Process(target=child_process)
     p.start()
-    child_started.wait()
+    sleep(1)
     return_pid.value = p.pid
 
 def task_from_process(name):

--- a/t/unit/test_spawn.py
+++ b/t/unit/test_spawn.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 
-from billiard import get_context
+import sys
+from billiard import get_context, Value, Process
+from billiard.util import set_pdeathsig
+import pytest
+import psutil
+import signal
+from time import sleep
 
 class test_spawn:
     def test_start(self):
@@ -10,6 +16,27 @@ class test_spawn:
         p.start()
         p.join()
         return p.exitcode
+
+    @pytest.mark.skipif(not sys.platform.startswith('linux'),
+                        reason='set_pdeathsig() is supported only in Linux')
+    def test_set_pdeathsig(self):
+        return_pid = Value('i')
+        p = Process(target=parent_task, args=(return_pid,))
+        p.start()
+        p.join()
+        with pytest.raises(psutil.NoSuchProcess):
+            proc = psutil.Process(return_pid.value)
+
+def child_process():
+    set_pdeathsig(signal.SIGTERM)
+    while True:
+        sleep(1)
+
+def parent_task(return_pid):
+    p = Process(target=task_from_process, args=('opa',))
+    p.start()
+    sleep(1)
+    return_pid.value = p.pid
 
 def task_from_process(name):
     print('proc:', name)

--- a/t/unit/test_spawn.py
+++ b/t/unit/test_spawn.py
@@ -23,8 +23,9 @@ class test_spawn:
         return_pid = Value('i')
         p = Process(target=parent_task, args=(return_pid,))
         p.start()
-        p.join()
-        sleep(5)    # We need to wait to have child process killed.
+        sleep(3) # wait for setting pdeathsig
+        p.terminate()
+        sleep(3) # wait for process termination
         with pytest.raises(psutil.NoSuchProcess):
             proc = psutil.Process(return_pid.value)
 
@@ -45,7 +46,7 @@ def child_process():
 def parent_task(return_pid):
     p = Process(target=child_process)
     p.start()
-    sleep(1)
+    sleep(1) # Wait for starting process
     return_pid.value = p.pid
 
 def task_from_process(name):

--- a/t/unit/test_spawn.py
+++ b/t/unit/test_spawn.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
 import sys
-from billiard import get_context, Value, Process
-from billiard.util import set_pdeathsig
+from billiard import get_context, Value, Process, Event
+from billiard.util import set_pdeathsig, get_pdeathsig
 import pytest
 import psutil
 import signal
@@ -24,18 +24,28 @@ class test_spawn:
         p = Process(target=parent_task, args=(return_pid,))
         p.start()
         p.join()
+        sleep(1)    # We need to wait to have child process killed.
         with pytest.raises(psutil.NoSuchProcess):
             proc = psutil.Process(return_pid.value)
 
-def child_process():
+    def test_set_get_pdeathsig(self):
+        sig = get_pdeathsig()
+        assert sig == 0
+        set_pdeathsig(signal.SIGTERM)
+        sig = get_pdeathsig()
+        assert sig == signal.SIGTERM
+
+def child_process(child_started):
     set_pdeathsig(signal.SIGTERM)
+    child_started.set()
     while True:
         sleep(1)
 
 def parent_task(return_pid):
-    p = Process(target=task_from_process, args=('opa',))
+    child_started = Event()
+    p = Process(target=child_process, args=(child_started,))
     p.start()
-    sleep(1)
+    child_started.wait()
     return_pid.value = p.pid
 
 def task_from_process(name):

--- a/t/unit/test_win32.py
+++ b/t/unit/test_win32.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
 import pytest
+import signal
 
 from case import skip
+from billiard.util import set_pdeathsig, get_pdeathsig
 
 from billiard.compat import _winapi
 
@@ -68,3 +70,11 @@ class test_win32_module:
     ])
     def test_functions(self, name):
         assert getattr(_winapi, name)
+
+    def test_set_pdeathsig(self):
+        with pytest.raises(OSError):
+            set_pdeathsig(signal.SIGTERM)
+
+    def test_get_pdeathsig(self):
+        with pytest.raises(OSError):
+            get_pdeathsig(signal.SIGTERM)

--- a/t/unit/test_win32.py
+++ b/t/unit/test_win32.py
@@ -77,4 +77,4 @@ class test_win32_module:
 
     def test_get_pdeathsig(self):
         with pytest.raises(OSError):
-            get_pdeathsig(signal.SIGTERM)
+            get_pdeathsig()


### PR DESCRIPTION
Currently, when parent process is killed, the child process continue to run as zombie:
```
(celery36) [root@debian billiard]# python
Python 3.6.3 (default, Jan  9 2018, 10:19:07)
Type "help", "copyright", "credits" or "license" for more information.
>>> from time import sleep
>>> import signal
>>> from billiard import Process
>>> import os
>>>
>>> def f():
...     while True:
...         print('hello from PID ', os.getpid())
...         sleep(1)
...
>>> if __name__ == '__main__':
...     print('Parent process with PID ', os.getpid())
...     p = Process(target=f)
...     p.start()
...     p.join()
...
Parent process with PID  51226
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
Killed
(celery36) [root@debian billiard]# hello from PID  51232
hello from PID  51232
hello from PID  51232
hello from PID  51232
```
The process above was killed from another terminal:
```
[root@debian ~]# kill -KILL 51226
```

This is causing issues as e.g. in Celery: https://github.com/celery/celery/issues/102

Problem with killed parent can be solved using parent process death signals. For more details see [1] [2]. With this PR child will be killed when parent terminates:
```
(celery36) [root@debian billiard]# python
Python 3.6.3 (default, Jan  9 2018, 10:19:07)
Type "help", "copyright", "credits" or "license" for more information.
>>> from time import sleep
>>> import signal
>>> from billiard import Process
>>> from billiard.util import set_pdeathsig
>>> import os
>>>
>>> def f():
...     set_pdeathsig(signal.SIGTERM)
...     while True:
...         print('hello from PID ', os.getpid())
...         sleep(1)
...
>>> if __name__ == '__main__':
...     print('Parent process with PID ', os.getpid())
...     p = Process(target=f)
...     p.start()
...     p.join()
...
Parent process with PID  51789
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
hello from PID  51795
Killed
(celery36) [root@debian billiard]#
```
The parent was killed from another terminal using:
```
[root@debian ~]# kill -KILL 51789
```
The only disadvantage of added functions is that they are not supported on Windows platform. On windows platform `OSError` is raised.

This functionality can be applied also to Celery by simply adding to `celery.concurrency.prefork.process_initializer()` function [3] line `set_pdeathsig(signal.SIGKILL)`

```python 
def process_initializer(app, hostname):
    """Pool child process initializer.

    Initialize the child pool process to ensure the correct
    app instance is used and things like logging works.
    """
    set_pdeathsig(signal.SIGKILL)
    _set_task_join_will_block(True)
```
After this fix will Operating system automatically kill all workers of celery after crash of main process instead of having them running as zombies.

[1] http://smackerelofopinion.blogspot.com/2015/11/using-prsetpdeathsig-to-reap-child.html
[2] https://linux.die.net/man/2/prctl
[3] https://github.com/celery/celery/blob/6bd31f19e0b68a5b595d8a254dac9e4cc570cccc/celery/concurrency/prefork.py#L42