### PR TITLE
Remove checks/workarounds for unsupported Pythons

### DIFF
--- a/billiard/common.py
+++ b/billiard/common.py
@@ -17,15 +17,9 @@ except ImportError:  # pragma: no cover
 from .exceptions import RestartFreqExceeded
 from .five import monotonic
 
-if sys.version_info < (2, 6):  # pragma: no cover
-    # cPickle does not use absolute_imports
-    pickle = pypickle
-    pickle_load = pypickle.load
-    pickle_loads = pypickle.loads
-else:
-    pickle = cpickle or pypickle
-    pickle_load = pickle.load
-    pickle_loads = pickle.loads
+pickle = cpickle or pypickle
+pickle_load = pickle.load
+pickle_loads = pickle.loads
 
 # cPickle.loads does not support buffer() objects,
 # but we can just create a StringIO and use load.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from distutils.errors import (
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-if sys.platform == 'win32' and sys.version_info >= (2, 6):
+if sys.platform == 'win32':
     # distutils.msvc9compiler can raise IOError if the compiler is missing
     ext_errors += (IOError, )
 


### PR DESCRIPTION
Billiard only supports Pyton 2.7 & 3.4+. Can drop these unused checks.