### PR TITLE
Fix warm shutdown crash from timeout handler

### DIFF
--- a/t/unit/test_pool.py
+++ b/t/unit/test_pool.py
@@ -8,3 +8,13 @@ class test_pool:
         assert pool.did_start_ok() is True
         pool.close()
         pool.terminate()
+
+    def test_timeout_handler_iterates_with_cache(self):
+        # Given a pool
+        pool = billiard.pool.Pool()
+        # If I have a cache containing async results
+        cache = {n: pool.apply_async(n) for n in range(4)}
+        # And a TimeoutHandler with that cache
+        timeout_handler = pool.TimeoutHandler(pool._pool, cache, 0, 0)
+        # If I call to handle the timeouts I expect no exception
+        next(timeout_handler.handle_timeouts())


### PR DESCRIPTION
This is an attempt at fixing #260 while attempting to not break #249.

I was unable to reproduce #249, so this is a bit of a guess, but my
thinking is that we shouldn't need to do a deep copy here because we're
not iterating over the values, just the keys, and a shallow copy
protects us from that.

Also, assuming that the cache keys can change within the loop, this moves
the copy inside the loop, and drops the explicit `list()` since we have
a proper copy already.