### PR TITLE
Pass arguments when wrapping sys.exit

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -277,7 +277,7 @@ class Worker(object):
 
         def exit(status=None):
             _exitcode[0] = status
-            if sys.platform == 'win32' and sys.version_info < (3,0)
+            if sys.platform == 'win32' and sys.version_info < (3,0):
                 return _exit()
             return _exit(status)
         sys.exit = exit

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -277,7 +277,7 @@ class Worker(object):
 
         def exit(status=None):
             _exitcode[0] = status
-            return _exit()
+            return _exit(status)
         sys.exit = exit
 
         pid = os.getpid()

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -277,6 +277,8 @@ class Worker(object):
 
         def exit(status=None):
             _exitcode[0] = status
+            if sys.platform == 'win32' and sys.version_info < (3,0)
+                return _exit()
             return _exit(status)
         sys.exit = exit
 


### PR DESCRIPTION
The `sys.exit()` wrapping in `pool.Worker.__call__` does not pass `status` to `sys.exit(arg)`. This is an issue with 3rd party libs that use `sys.exit(message)` for fatal conditions.

E.g.:

```python
def in_third_party():
   sys.exit("I cannot go on")

@celery.task
def do_third_party_call():
  try:
    in_third_party()
  except SystemExit as exc:
    logger.error(str(exc))
    handle_error_message(str(exc))
```

This will log `"I cannot go on"` and pass it for handling as long as we are not inside of a celery worker. Inside of a worker, it will log `""`.

It might be arguable whether using `sys.exit()` in such a way is good design, but since this use is even suggested by the Python documentation, and since there is often no choice or control over 3rd party libs, it's something to live with.

The patch is intentionally minimal. I'm not certain exactly what's going on at that point in the code, and "fork" points are always finicky across platforms. So while I don't quite understand why `sys.exit()` needs to be patched in the first place, I've just passed the parameter on so it can be caught by tasks.

