### PR TITLE
Remove win32/py2k special

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -277,8 +277,6 @@ class Worker(object):
 
         def exit(status=None):
             _exitcode[0] = status
-            if sys.platform == 'win32' and sys.version_info < (3,0):
-                return _exit()
             return _exit(status)
         sys.exit = exit
 


### PR DESCRIPTION
Introduced in c2c23abb030f19dc5c9767f5ffdcad21edc886f4 but not testable as win32/py2k fails anyway. 