### PR TITLE
Allow pytest 5

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
 case>=1.3.1
-pytest<5
+pytest<6
 psutil


### PR DESCRIPTION
The test suite passes here with pytest 5.0.1 on both python 3.7.4 and 2.7.16.