### PR TITLE
Update version to match latest pypi release version and not prior.

### DIFF
--- a/billiard/__init__.py
+++ b/billiard/__init__.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import sys
 from . import context
 
-VERSION = (3, 6, 0, 0)
+VERSION = (3, 6, 1, 0)
 __version__ = '.'.join(map(str, VERSION[0:4])) + "".join(VERSION[4:])
 __author__ = 'R Oudkerk / Python Software Foundation'
 __author_email__ = 'python-dev@python.org'


### PR DESCRIPTION
Current version on pypi is 3.6.1.0 https://pypi.org/project/billiard/ but when you install from master repository and do a pip freeze it says its 3.6.0.0 because of this.