### PR TITLE
upgrade to pytest<6 Fixes #297

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
 case>=1.3.1
-pytest<5
+pytest<6
 psutil


### PR DESCRIPTION
pip uses pytest's requires_python to pick the right version for 2.7 and 3+