### PR TITLE
In PyPy 2 IOError is thrown in bootstrap

### DIFF
--- a/billiard/process.py
+++ b/billiard/process.py
@@ -296,7 +296,7 @@ class BaseProcess(object):
                 try:
                     sys.stdin.close()
                     sys.stdin = open(os.devnull)
-                except (OSError, ValueError):
+                except (EnvironmentError, OSError, ValueError):
                     pass
             old_process = _current_process
             _set_current_process(self)


### PR DESCRIPTION
```
Process unittest:
Traceback (most recent call last):
  File "/home/arcivanov/Documents/src/arcivanov/pybuilder/.pybuilder/plugins/pypy-2.7.13.final.42/site-packages/billiard/process.py", line 297, in _bootstrap
    sys.stdin.close()
IOError: [Errno 9] Bad file descriptor: '<fdopen>'
```

In Python 3 OSError is a super of EnvironmentError, IOError and all other environmental errors.
In Python 2 in general EnvironmentError is a super of IOError, OSError and socket.error (since 2.6)
However, in Python 2 OSError is a sibling of IOError and therefore IOError goes uncaught.
This ensures that OS/IO errors are truly ignored across Python versions and flavors.