### PR TITLE
The inqueue and outqueue may already be None.

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1694,8 +1694,10 @@ class Pool(object):
                         p.join()
             debug('pool workers joined')
 
-        inqueue.close()
-        outqueue.close()
+        if inqueue:
+            inqueue.close()
+        if outqueue:
+            outqueue.close()
 
     @property
     def process_sentinels(self):


### PR DESCRIPTION
In this case, there's no need to close them when terminating.

This should resolve the bug discovered in https://travis-ci.org/celery/celery/jobs/645891388#L3162

Fixes #306 