### PR TITLE
Remove deprecated use of 'setup.py test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ test-all: clean-pyc
 	$(TOX)
 
 test:
-	$(PYTHON) setup.py test
+	tox -e py
 
 cov:
 	$(NOSETESTS) -xv --with-coverage --cover-html --cover-branch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,12 +53,12 @@ init:
 
 install:
   - "powershell appveyor\\install.ps1"
-  - "%PYTHON%/Scripts/pip.exe install -U setuptools"
+  - "%PYTHON%/Scripts/pip.exe install tox"
 
 build: off
 
 test_script:
-  - "%WITH_COMPILER% %PYTHON%/python setup.py test"
+  - "%WITH_COMPILER% %PYTHON%/python -m tox -e py"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%/python setup.py bdist_wheel"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import sys
 import glob
 
 import setuptools
-import setuptools.command.test
 
 from distutils import sysconfig
 from distutils.errors import (
@@ -165,31 +164,10 @@ is_jython = sys.platform.startswith('java')
 is_pypy = hasattr(sys, 'pypy_version_info')
 
 
-def strip_comments(l):
-    return l.split('#', 1)[0].strip()
-
-
-def reqs(f):
-    return list(filter(None, [strip_comments(l) for l in open(
-        os.path.join(os.getcwd(), 'requirements', f)).readlines()]))
-
-
 def _is_build_command(argv=sys.argv, cmds=('install', 'build', 'bdist')):
     for arg in argv:
         if arg.startswith(cmds):
             return arg
-
-
-class pytest(setuptools.command.test.test):
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
-
-    def initialize_options(self):
-        setuptools.command.test.test.initialize_options(self)
-        self.pytest_args = []
-
-    def run_tests(self):
-        import pytest
-        sys.exit(pytest.main(self.pytest_args))
 
 
 def run_setup(with_extensions=True):
@@ -233,8 +211,6 @@ def run_setup(with_extensions=True):
         url=meta['homepage'],
         zip_safe=False,
         license='BSD',
-        tests_require=reqs('test.txt'),
-        cmdclass={'test': pytest},
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',

--- a/t/integration/setup.py
+++ b/t/integration/setup.py
@@ -23,7 +23,7 @@ The billiard functional test suite cannot be installed.
 
 But you can execute the tests by running the command:
 
-    $ python setup.py test
+    $ tox -e py
 
 
 """)


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now unify on tox as the default test
entry point.