### PR TITLE
Issue #309: Add Python 3.9 support to spawnv_passfds()

### DIFF
--- a/billiard/compat.py
+++ b/billiard/compat.py
@@ -220,10 +220,14 @@ else:
         passfds = sorted(passfds)
         errpipe_read, errpipe_write = os.pipe()
         try:
-            return _posixsubprocess.fork_exec(
+            args = [
                 args, [fsencode(path)], True, tuple(passfds), None, None,
                 -1, -1, -1, -1, -1, -1, errpipe_read, errpipe_write,
-                False, False, None)
+                False, False]
+            if sys.version_info >= (3, 9):
+                args.extend((None, None, None, -1))  # group, extra_groups, user, umask
+            args.append(None)  # preexec_fn
+            return _posixsubprocess.fork_exec(*args)
         finally:
             os.close(errpipe_read)
             os.close(errpipe_write)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3{5,6,7,8}, pypy{,3}
+envlist = py27, py3{5,6,7,8,9}, pypy{,3}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.9 added (umask, user, group, extra_groups) parameters to
_posixsubprocess.fork_exec().