### PR TITLE
 due to circular reference of local variable in Exception

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -37,10 +37,6 @@ class _Frame(object):
             "__loader__": None,
         }
         self.f_locals = fl = {}
-        try:
-            fl["__traceback_hide__"] = frame.f_locals["__traceback_hide__"]
-        except KeyError:
-            pass
         self.f_back = None
         self.f_trace = None
         self.f_exc_traceback = None


### PR DESCRIPTION
resolved: #311
While the Except statement was in progress, an error occurred that the Garbage Collector could not collect by referring to the f_locals of the frame.