### PR TITLE
#296 Add job id to WorkerLostError message

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1263,8 +1263,8 @@ class Pool(object):
     def mark_as_worker_lost(self, job, exitcode):
         try:
             raise WorkerLostError(
-                'Worker exited prematurely: {0}.'.format(
-                    human_status(exitcode)),
+                'Worker exited prematurely: {0} Job: {1}.'.format(
+                    human_status(exitcode), job._job),
             )
         except WorkerLostError:
             job._set(None, (False, ExceptionInfo()))

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 case>=1.3.1
 pytest<6
 # psutil is pinned since this is the last version that supports pypy2
-psutil=5.6.3
+psutil==5.6.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 case>=1.3.1
 pytest<6
-psutil
+# psutil is pinned since this is the last version that supports pypy2
+psutil=5.6.3


### PR DESCRIPTION
Ticket Id: #296 
This adds a job id to the WorkerLostError error message so that it's easier to figure out which job was killed with a worker lost. 

Alternatively, if you don't want to change the exception message I can add this as a separate debug message



