### PR TITLE
Support Sphinx 4.x

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -170,8 +170,8 @@ htmlhelp_basename = 'multiprocessingdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).
 latex_documents = [
-  ('index', 'multiprocessing.tex', ur'multiprocessing Documentation',
-   ur'Python Software Foundation', 'manual'),
+  ('index', 'multiprocessing.tex', 'multiprocessing Documentation',
+   'Python Software Foundation', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
The newer Sphinx version stumbles over the `ur` annotation. since it isn't containing any non-ascii characters, we can omit it.