### PR TITLE
Fix PyPI: README is RST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,6 @@ def run_setup(with_extensions=True):
         version=meta['VERSION'],
         description=meta['doc'],
         long_description=long_description,
-        long_description_content_type='text/markdown',
         packages=packages,
         ext_modules=extensions,
         author=meta['author'],


### PR DESCRIPTION
Currently the README isn't rendered properly on [PyPI](https://pypi.org/project/billiard/):

![image](https://user-images.githubusercontent.com/1324225/121821838-3f155e80-cca4-11eb-9c92-06b0254f3adf.png)


The README is reStructuredText, so leave out `long_description_content_type` to default to RST.

Alternatively, if you prefer Markdown (I do!), I can convert the README to MD.