### PR TITLE
Replace deprecated threading Event.isSet with Event.is_set

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1749,7 +1749,7 @@ class ApplyResult(object):
         )
 
     def ready(self):
-        return self._event.isSet()
+        return self._event.is_set()
 
     def accepted(self):
         return self._accepted


### PR DESCRIPTION
Prevent deprecation warnings on Python 3.10

Event.is_set has been available since Python 2.6 and is effectively the same as Event.isSet