### PR TITLE
Keep exception traceback somehow

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -130,4 +130,19 @@ class ExceptionInfo:
 
     @property
     def exc_info(self):
-        return self.type, self.exception, self.tb
+        return self.type, self.exception, self.raw_tb
+
+
+class BilliardException(Exception):
+
+    def __init__(self, exc_info):
+        super().__init__()
+        self.cause = exc_info.exception
+        self.tb = exc_info.tb
+        self.traceback = exc_info.traceback
+
+    def __str__(self):
+        return self.traceback
+
+    def __repr__(self):
+        return "<BilliardException: %r>" % self.cause

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1785,7 +1785,7 @@ class ApplyResult:
         if self._success:
             return self._value
         else:
-            raise self._value.exception
+            raise self._value.exception.with_traceback(self._value.tb)
 
     def safe_apply_callback(self, fun, *args, **kwargs):
         if fun:

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -30,7 +30,7 @@ from .common import (
     TERM_SIGNAL, human_status, pickle_loads, reset_signals, restart_state,
 )
 from .compat import get_errno, mem_rss, send_offset
-from .einfo import ExceptionInfo
+from .einfo import ExceptionInfo, BilliardException
 from .dummy import DummyProcess
 from .exceptions import (
     CoroStop,
@@ -1785,7 +1785,7 @@ class ApplyResult:
         if self._success:
             return self._value
         else:
-            raise self._value.exception.with_traceback(self._value.tb)
+            raise BilliardException(self._value) from self._value.exception
 
     def safe_apply_callback(self, fun, *args, **kwargs):
         if fun:

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -30,7 +30,7 @@ from .common import (
     TERM_SIGNAL, human_status, pickle_loads, reset_signals, restart_state,
 )
 from .compat import get_errno, mem_rss, send_offset
-from .einfo import ExceptionInfo, BilliardException
+from .einfo import ExceptionInfo
 from .dummy import DummyProcess
 from .exceptions import (
     CoroStop,
@@ -1785,7 +1785,7 @@ class ApplyResult:
         if self._success:
             return self._value
         else:
-            raise BilliardException(self._value) from self._value.exception
+            raise self._value.exception
 
     def safe_apply_callback(self, fun, *args, **kwargs):
         if fun:

--- a/t/unit/test_pool.py
+++ b/t/unit/test_pool.py
@@ -1,12 +1,13 @@
 import billiard.pool
-import billiard.einfo
 import time
 import pytest
+
 
 def func(x):
     if x == 2:
         raise ValueError
     return x
+
 
 class test_pool:
     def test_raises(self):
@@ -33,9 +34,8 @@ class test_pool:
         pool.close()
         pool.join()
         pool.terminate()
-        
+
         for i, res in enumerate(results):
             if i == 2:
-                with pytest.raises(billiard.einfo.BilliardException):
+                with pytest.raises(ValueError):
                     res.get()
-        


### PR DESCRIPTION
If an exception happens in a pool worker (like when doing `apply_async`) the exception that gets raised during the collection of apply results via `.get()` loses the traceback that lead to it and only has the traceback of the `.get()` call that caused it.

This PR preserves the traceback somehow, at the cost of using a custom Exception type and storing the traceback there. I wonder what multiprocessing does to pickle the traceback and reconstruct it on the `.get()` side.