### PR TITLE
ExceptionInfo.exception should be an exception

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -91,15 +91,23 @@ class Traceback:
 class RemoteTraceback(Exception):
     def __init__(self, tb):
         self.tb = tb
+
     def __str__(self):
         return self.tb
 
-class ExceptionWithTraceback:
+
+class ExceptionWithTraceback(Exception):
     def __init__(self, exc, tb):
         self.exc = exc
         self.tb = '\n"""\n%s"""' % tb
+        super().__init__()
+
+    def __str__(self):
+        return self.tb
+
     def __reduce__(self):
         return rebuild_exc, (self.exc, self.tb)
+
 
 def rebuild_exc(exc, tb):
     exc.__cause__ = RemoteTraceback(tb)

--- a/t/unit/test_einfo.py
+++ b/t/unit/test_einfo.py
@@ -1,0 +1,28 @@
+import pickle
+import logging
+from billiard.einfo import ExceptionInfo
+
+logger = logging.getLogger(__name__)
+
+
+def test_exception_info_log_before_pickle(caplog):
+    try:
+        raise RuntimeError("some message")
+    except Exception:
+        exception = ExceptionInfo().exception
+
+    logger.exception("failed", exc_info=exception)
+    assert ' raise RuntimeError("some message")' in caplog.text
+    assert "RuntimeError: some message" in caplog.text
+
+
+def test_exception_info_log_after_pickle(caplog):
+    try:
+        raise RuntimeError("some message")
+    except Exception:
+        exception = ExceptionInfo().exception
+        exception = pickle.loads(pickle.dumps(exception))
+
+    logger.exception("failed", exc_info=exception)
+    assert ' raise RuntimeError("some message")' in caplog.text
+    assert "RuntimeError: some message" in caplog.text


### PR DESCRIPTION
Closes #371 

Celery expects `ExceptionInfo.exception` to be an exception:

https://github.com/celery/celery/blob/feaad3f9fdf98d0453a07a68e307e48c6c3c2550/celery/app/trace.py#L239

This MR makes sure it is an exception while at the same time preserving the cause while pickling (tested with Celery 5.3.0b1).