### PR TITLE
Add Code.co_positions for python 3.11 support

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -20,7 +20,8 @@ class _Code:
         self.co_lnotab = b''
         self.co_names = code.co_names
         self.co_nlocals = code.co_nlocals
-        self.co_positions = code.co_positions
+        if hasattr(code, "co_positions"):
+            self.co_positions = code.co_positions
         self.co_stacksize = code.co_stacksize
         self.co_varnames = ()
 

--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -20,6 +20,7 @@ class _Code:
         self.co_lnotab = b''
         self.co_names = code.co_names
         self.co_nlocals = code.co_nlocals
+        self.co_positions = code.co_positions
         self.co_stacksize = code.co_stacksize
         self.co_varnames = ()
 


### PR DESCRIPTION
The new property [`co_positions`](https://docs.python.org/3/reference/datamodel.html#codeobject.co_positions) needs to be pulled through for Exception handling in python 3.11 to work.

Addresses  #377