### PR TITLE
Add missing attribute co_positions for Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Install system packages
         run: sudo apt update && sudo apt-get install libcurl4-openssl-dev libssl-dev

--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -22,6 +22,13 @@ class _Code:
         self.co_nlocals = code.co_nlocals
         self.co_stacksize = code.co_stacksize
         self.co_varnames = ()
+        if sys.version_info >= (3, 11):
+            self._co_positions = list(code.co_positions())
+
+    if sys.version_info >= (3, 11):
+        @property
+        def co_positions(self):
+            return self._co_positions.__iter__
 
 
 class _Frame:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox-gh-actions
-envlist = {3.7,3.8,3.9,3.10}-unit
+envlist = {3.7,3.8,3.9,3.10,3.11}-unit
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -10,6 +10,7 @@ python =
     3.8: 3.8-unit
     3.9: 3.9-unit
     3.10: 3.10-unit
+    3.11: 3.11-unit
 
 [testenv]
 distribute = True


### PR DESCRIPTION
This PR addresses #377 and enables CI for Python 3.11.

Converting `code.co_positions()` to a `list` strips `code` objects in its attributes that would otherwise prevent the `_Code` object from being pickled. Without this change, `test_exception_traceback_present` never terminates.