### PR TITLE
Switch references to the master branch to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '40 0 * * 5'
 

--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,11 @@ billiard
 
 |build-status-lin| |build-status-win| |license| |wheel| |pyversion| |pyimp|
 
-.. |build-status-lin| image:: https://secure.travis-ci.org/celery/billiard.png?branch=master
+.. |build-status-lin| image:: https://github.com/celery/billiard/actions/workflows/ci.yaml/badge.svg
     :alt: Build status on Linux
-    :target: https://travis-ci.org/celery/billiard
+    :target: https://github.com/celery/billiard/actions/workflows/ci.yaml
 
-.. |build-status-win| image:: https://ci.appveyor.com/api/projects/status/github/celery/billiard?png=true&branch=master
+.. |build-status-win| image:: https://ci.appveyor.com/api/projects/status/github/celery/billiard?png=true&branch=main
     :alt: Build status on Windows
     :target: https://ci.appveyor.com/project/ask/billiard
 


### PR DESCRIPTION
This PR changes the remains of the references to master that we didn't change yet to main.
I also noticed our build status still refers to Travis which is now not in use anymore so we now use the correct badge from Github Actions.