### PR TITLE
Update process.py to close during join only if process has completed

### DIFF
--- a/billiard/process.py
+++ b/billiard/process.py
@@ -144,7 +144,7 @@ class BaseProcess:
         res = self._popen.wait(timeout)
         if res is not None:
             _children.discard(self)
-        self.close()
+            self.close()
 
     def is_alive(self):
         '''


### PR DESCRIPTION
If a timeout is set, the wait will return before process exit. `close` deletes the sentinel and breaks future `join` calls.

These 4 spaces allow multiple joins with a a `timeout`, as `multiprocessing` does.

Should fix #270.