### PR TITLE
Make einfo compatible with inspect (fixes #176)

### DIFF
--- a/billiard/einfo.py
+++ b/billiard/einfo.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+import types
 
 __all__ = ['ExceptionInfo', 'Traceback']
 
@@ -24,6 +25,10 @@ class _Code:
         self.co_varnames = ()
         if sys.version_info >= (3, 11):
             self._co_positions = list(code.co_positions())
+
+    @property
+    def __class__(self):
+        return types.CodeType
 
     if sys.version_info >= (3, 11):
         @property
@@ -57,6 +62,10 @@ class _Frame:
         # don't want to hit https://bugs.python.org/issue21967
         self.f_restricted = False
 
+    @property
+    def __class__(self):
+        return types.FrameType
+
 
 class _Object:
 
@@ -79,6 +88,10 @@ class _Truncated:
         self.tb_next = None
         self.tb_lasti = 0
 
+    @property
+    def __class__(self):
+        return types.TracebackType
+
 
 class Traceback:
     Frame = _Frame
@@ -93,6 +106,10 @@ class Traceback:
                 self.tb_next = Traceback(tb.tb_next, max_frames, depth + 1)
             else:
                 self.tb_next = _Truncated()
+
+    @property
+    def __class__(self):
+        return types.TracebackType
 
 
 class RemoteTraceback(Exception):

--- a/t/unit/test_einfo.py
+++ b/t/unit/test_einfo.py
@@ -1,6 +1,9 @@
+import sys
 import pickle
 import logging
-from billiard.einfo import ExceptionInfo
+import inspect
+import types
+from billiard.einfo import ExceptionInfo, Traceback, _Code, _Frame
 
 logger = logging.getLogger(__name__)
 
@@ -26,3 +29,36 @@ def test_exception_info_log_after_pickle(caplog):
     logger.exception("failed", exc_info=exception)
     assert ' raise RuntimeError("some message")' in caplog.text
     assert "RuntimeError: some message" in caplog.text
+
+
+def make_python_tb():
+    tb = None
+    depth = 0
+    while True:
+        try:
+            frame = sys._getframe(depth)
+        except ValueError:
+            break
+        else:
+            depth += 1
+
+        tb = types.TracebackType(tb, frame, frame.f_lasti, frame.f_lineno)
+
+    return tb
+
+
+class test_inspect:
+    def test_istraceback(self):
+        assert inspect.istraceback(Traceback(tb=make_python_tb()))
+
+    def test_isframe(self):
+        assert inspect.isframe(_Frame(make_python_tb().tb_frame))
+
+    def test_iscode(self):
+        assert inspect.iscode(_Code(make_python_tb().tb_frame.f_code))
+
+    def test_getframeinfo(self):
+        assert inspect.getframeinfo(Traceback(tb=make_python_tb()))
+
+    def test_getinnerframes(self):
+        assert inspect.getinnerframes(Traceback(tb=make_python_tb()))


### PR DESCRIPTION
Libraries like `sentry` or `better-exceptions` will fail while traversing exception chains with `getframeinfo` like this:

```
AttributeError: 'Traceback' object has no attribute 'f_lineno'
```

As mentioned in #176, we can not inherit from `types.Traceback` and friends, but it's possible to override `__class__` which will make the `isinstance` check pass. This is also used internally by Python's `unittest.mock` module:

```
    @property
    def __class__(self):
        if self._spec_class is None:
            return type(self)
        return self._spec_class
```