### PR TITLE
FIX: Replaced mktemp usage for PY2 with Python 3 ones.

### DIFF
--- a/billiard/heap.py
+++ b/billiard/heap.py
@@ -90,15 +90,12 @@ else:
                         f.write(b'\0' * (size % bs))
                         assert f.tell() == size
                 else:
-                    name = tempfile.mktemp(
+                    self.fd, name = tempfile.mkstemp(
                         prefix='pym-%d-' % (os.getpid(),),
                         dir=util.get_temp_dir(),
                     )
-                    self.fd = os.open(
-                        name, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600,
-                    )
-                    util.Finalize(self, os.close, (self.fd,))
                     os.unlink(name)
+                    util.Finalize(self, os.close, (self.fd,))
                     os.ftruncate(self.fd, size)
             self.buffer = mmap.mmap(self.fd, self.size)
 


### PR DESCRIPTION
Issue: https://github.com/celery/billiard/issues/393

### Details

In file: [heap.py](https://github.com/celery/billiard/blob/main/billiard/heap.py#L93), there is a method  that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of `mktemp` with `mkstemp`. 

The changes are made to the part relevant to Python 2.0 for backward compatibility. However, in case of a full shift to Python 3.8+, the following code can be omitted-

```python
else:
    self.fd, name = tempfile.mkstemp(
        prefix='pym-%d-' % (os.getpid(),),
        dir=util.get_temp_dir(),
    )
    os.unlink(name)
    util.Finalize(self, os.close, (self.fd,))
    os.ftruncate(self.fd, size)
```

### CLA Requirements:
This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
- [Git Commit SignOff documentation](https://developercertificate.org/)


### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.