### PR TITLE
Adapt for logging lock internal changes in Python3.13

### DIFF
--- a/billiard/util.py
+++ b/billiard/util.py
@@ -128,7 +128,12 @@ def get_logger():
     global _logger
     import logging
 
-    logging._acquireLock()
+    try:
+        # Python 3.13+
+        acquire, release = logging._prepareFork, logging._afterFork
+    except AttributeError:
+        acquire, release = logging._acquireLock, logging._releaseLock
+    acquire()
     try:
         if not _logger:
 
@@ -145,7 +150,7 @@ def get_logger():
                 atexit._exithandlers.remove((_exit_function, (), {}))
                 atexit._exithandlers.append((_exit_function, (), {}))
     finally:
-        logging._releaseLock()
+        release()
 
     return _logger
 


### PR DESCRIPTION
Fixes #403.

A brief discussion of the approach is in https://github.com/celery/billiard/issues/403#issuecomment-2169851972.

Tested with:

```
$ PYTHONPATH="${PWD}" python3.12 -c 'from billiard.util import get_logger; print(get_logger())'
<Logger multiprocessing (WARNING)>
$ PYTHONPATH="${PWD}" python3.13 -c 'from billiard.util import get_logger; print(get_logger())'
<Logger multiprocessing (WARNING)>
```