### PR TITLE
BF: restrict value of get_fdmax

### DIFF
--- a/billiard/compat.py
+++ b/billiard/compat.py
@@ -107,7 +107,7 @@ def get_fdmax(default=None):
     except:
         fdmax = None
 
-    if not fdmax:
+    if fdmax is None:
         if resource is None:  # Windows
             return default
         fdmax = resource.getrlimit(resource.RLIMIT_NOFILE)[1]

--- a/billiard/compat.py
+++ b/billiard/compat.py
@@ -123,9 +123,10 @@ def get_fdmax(default=None):
         else:
             fdmax_limited = 10000
             msg = "a new smaller"
-        warnings.warn(UserWarning(
+        warnings.warn(
            f"System set max number of open files ({fdmax}) is way too high. "
-           f"Will use {msg} value of {fdmax_limited}"))
+           f"Will use {msg} value of {fdmax_limited}",
+           UserWarning)
         return fdmax_limited
     else:
         return fdmax

--- a/billiard/compat.py
+++ b/billiard/compat.py
@@ -115,13 +115,13 @@ def get_fdmax(default=None):
             return default
     # Some system might be "mis"configured and allow for ulimit -n
     # of e.g. 1073741816 which would be infeasible to sweep through.
-    if fdmax >= 1e5:
+    if fdmax >= FD_MAX_LIMIT_THRESHOLD:
         # limiting value is ad-hoc and already more than sensible
         if default:
             fdmax_limited = default
             msg = "the default"
         else:
-            fdmax_limited = 10000
+            fdmax_limited = FD_MAX_DEFAULT_LIMIT
             msg = "a new smaller"
         warnings.warn(
            f"System set max number of open files ({fdmax}) is way too high. "


### PR DESCRIPTION
In my case I kept finding celery running at 100% and doing nothing.  py-spy pointed to the close_open_fds and then ulimit inside the container showed gory detail of

    ❯ docker run -it --rm --entrypoint bash dandiarchive/dandiarchive-api -c "ulimit -n"
    1073741816

situation is not unique to me. See more at

- https://github.com/dandi/dandi-cli/issues/1488

I verified that with this fix my celery container gets unstuck and proceeds to report useful errors ;) 