### PR TITLE
Fix the failing pre-commit.ci job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Learn more about this config here: https://pre-commit.com/
+
+# To enable these pre-commit hooks run: `uv tool install pre-commit`
+# or `pipx install pre-commit` or `brew install pre-commit`
+# Then in the project root directory run `pre-commit install`
+
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell # See pyproject.toml for args
+        additional_dependencies:
+          - tomli


### PR DESCRIPTION
Added configuration for pre-commit hooks including codespell.
* https://results.pre-commit.ci/repo/github/374820

A subset of #428
* #428