### PR TITLE
Propagate MemoryError from pool callbacks

### DIFF
--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -1797,6 +1797,8 @@ class ApplyResult:
         if fun:
             try:
                 fun(*args, **kwargs)
+            except MemoryError:
+                raise
             except self._callbacks_propagate:
                 raise
             except Exception as exc:

--- a/t/unit/test_pool.py
+++ b/t/unit/test_pool.py
@@ -19,6 +19,15 @@ def simple_task(x):
     return x * 2
 
 class test_pool:
+    def test_memory_error_from_callback_propagates(self):
+        def callback(value):
+            raise MemoryError(value)
+
+        result = billiard.pool.ApplyResult({}, callback)
+
+        with pytest.raises(MemoryError, match='out of memory'):
+            result._set(None, (True, 'out of memory'))
+
     def test_raises(self):
         pool = billiard.pool.Pool()
         assert pool.did_start_ok() is True


### PR DESCRIPTION
## Summary

- Propagate `MemoryError` raised by pool callbacks instead of logging and
  swallowing it.
- Add regression coverage through the `ApplyResult._set()` callback path.

On Python 3, `MemoryError` is an `Exception`, so the generic callback handler
currently catches it. Celery's request callback expects this exception to escape,
and swallowing it can leave an `acks_late` message unacknowledged. The explicit
`MemoryError` branch restores propagation without changing how other callback
exceptions or `callbacks_propagate` are handled.

Related to celery/celery#10462. A Celery regression around `Request.on_failure`
remains a follow-up after the billiard behavior is available.

## Validation

All tests were run in an isolated Python 3.12 Docker container.

- Before the fix, the new regression failed with `DID NOT RAISE MemoryError` and
  logged the callback exception.
- `python -m pytest t/unit/test_pool.py -q`: 6 passed.
- `python -m pytest t/unit -q`: 39 passed, 51 skipped.
- `python -m compileall -q billiard t/unit`: passed.
- `git diff --check`: passed.

## AI disclosure

This PR includes AI-assisted code understanding to speed up the process; the
implementation and tests were updated and reviewed manually with AI assistance.
