### PR TITLE
Propagate BaseException raised in pool workers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+Unreleased
+----------
+- Propagate `BaseException` raised in pool workers instead of raising
+  `WorkerLostError` (#427)
+
+
 4.3.0rc1 - 2026-02-26
 --------------------
 - Fix pytest deprecation warning (#440)

--- a/billiard/pool.py
+++ b/billiard/pool.py
@@ -360,7 +360,7 @@ class Worker:
                             continue  # received NACK
                     try:
                         result = (True, prepare_result(fun(*args, **kwargs)))
-                    except Exception:
+                    except BaseException:
                         result = (False, ExceptionInfo())
                     try:
                         put((READY, (job, i, result, inqW_fd)))

--- a/t/unit/test_pool.py
+++ b/t/unit/test_pool.py
@@ -18,6 +18,9 @@ def get_on_ready_count():
 def simple_task(x):
     return x * 2
 
+def raise_base_exception():
+    raise BaseException("base exception test")
+
 class test_pool:
     def test_memory_error_from_callback_propagates(self):
         def callback(value):
@@ -57,6 +60,17 @@ class test_pool:
             if i == 2:
                 with pytest.raises(ValueError):
                     res.get()
+
+    def test_base_exception_propagates(self):
+        pool = billiard.pool.Pool(1)
+        result = pool.apply_async(raise_base_exception)
+
+        with pytest.raises(BaseException, match="base exception test"):
+            result.get(timeout=10)
+
+        pool.close()
+        pool.join()
+        pool.terminate()
 
     def test_on_ready_counter_is_synchronized(self):
         for ctx in ('spawn', 'fork', 'forkserver'):


### PR DESCRIPTION
Closes #427.

A task that raises a `BaseException` (plain `BaseException`, `SystemExit`,
`KeyboardInterrupt`, …) was not caught by the worker's result marshalling —
the worker only caught `Exception` — so the exception propagated out of the
worker, the worker exited prematurely, and the caller got a confusing
`WorkerLostError` instead of the exception.

Change:

- `billiard/pool.py`: the worker's task-execution catch is now `except
  BaseException`, so any exception a task raises is marshalled back as a
  result and re-raised by `ApplyResult.get()` instead of killing the worker.

Test:

- Added `test_base_exception_propagates`, which submits a task raising
  `BaseException` and asserts `result.get()` raises it.

Ran `pytest t/unit/test_pool.py` locally — all 7 tests pass (including the
new one); without the fix the new test fails. The `ExceptionInfo` machinery
already handles any exception type (it rebuilds the original exception when
unpickling), so no further changes were needed on the parent side.
